### PR TITLE
Typo in InitializeSearchExample

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -172,7 +172,7 @@ var status = "";
 var stepsAllowed = 0;
 var runPauseButton;
 
-function initaliseSearchExample(rows, cols) {
+function initaliseSearchExample(cols, rows) {
     mapGraphic = null;
     gamemap = new MapFactory().getMap(cols, rows, 10, 10, 410, 410, allowDiagonals, percentWalls);
     start = gamemap.grid[0][0];


### PR DESCRIPTION
columns and rows were flipped. Very apparent if cols and rows are different from each other. If you create a cols=100 rows=50 maze the resulting grid will be an Array(50) with an Array(100) each instead of the other way round.