### PR TITLE
arr.splice instead of this.removeFromArray

### DIFF
--- a/astarpathfinder.js
+++ b/astarpathfinder.js
@@ -87,7 +87,8 @@ function AStarPathFinder(map, start, end, allowDiagonals) {
             }
 
             // Best option moves from openSet to closedSet
-            this.removeFromArray(this.openSet, current);
+            // this.removeFromArray(this.openSet, current);
+            this.openSet.splice(winner, 1);
             this.closedSet.push(current);
 
             // Check all the neighbors


### PR DESCRIPTION
I know this is old. But I've recently watched the YouTube video, and realized that you can just use the `winner `(since this is already the index) to splice from the `openSet`. 

> Note: I've attempted this locally in my own project. 

[Link to project](https://charbelsako.github.io/pacman/)
